### PR TITLE
refactor: unify command context detection

### DIFF
--- a/app/src/main/java/telegram/commands/AbstractCommand.java
+++ b/app/src/main/java/telegram/commands/AbstractCommand.java
@@ -70,23 +70,29 @@ public abstract class AbstractCommand implements AbilityExtension {
     @NonNull
     protected Predicate<Update> isSpecifiedContext(@NonNull MultiStateCommandTypes commandType) {
         return update -> {
-            boolean isSpecifiedContext = false;
-            if (update.getMessage().getText().equals("/end")){
+            if (isEndCommand(update)) {
                 return false;
             }
+            boolean isSpecifiedContext = false;
             try {
-                final UserContextDTO userContextDTO = dbDriver.selectUserContext(
-                        new UserContextSelectOptions(
-                                update.getMessage().getFrom().getId()
-                        )
-                );
-                if (userContextDTO != null && userContextDTO.getMultiStateCommandTypes() == commandType) {
-                    isSpecifiedContext = true;
-                }
+                isSpecifiedContext = isSpecifiedMultiStateCommandType(update, commandType);
             } catch (SQLException e) {
                 System.out.println(e);
             }
             return isSpecifiedContext;
         };
+    }
+
+    private boolean isEndCommand(@NonNull Update update) {
+        return update.getMessage().getText().equals("/end");
+    }
+
+    private boolean isSpecifiedMultiStateCommandType(@NonNull Update update, @NonNull MultiStateCommandTypes commandType) throws SQLException {
+        final UserContextDTO userContextDTO = dbDriver.selectUserContext(
+                new UserContextSelectOptions(
+                        update.getMessage().getFrom().getId()
+                )
+        );
+        return userContextDTO != null && userContextDTO.getMultiStateCommandTypes() == commandType;
     }
 }

--- a/app/src/main/java/telegram/commands/CreateDishCommand.java
+++ b/app/src/main/java/telegram/commands/CreateDishCommand.java
@@ -97,7 +97,7 @@ public class CreateDishCommand extends AbstractCommand {
                     }
                 },
                 Flag.TEXT,
-                isInCreateDishContext()
+                isSpecifiedContext(CREATE)
             )
             .build();
     }
@@ -207,28 +207,5 @@ public class CreateDishCommand extends AbstractCommand {
             sendSilently(BotMessages.SOMETHING_WENT_WRONG, update);
             System.out.println(e);
         }
-    }
-
-    @NonNull
-    private Predicate<Update> isInCreateDishContext() {
-        return update -> {
-            boolean isCreateDishContext = false;
-            if (update.getMessage().getText().equals("/end")){
-                return false;
-            }
-            try {
-                final UserContextDTO userContextDTO = dbDriver.selectUserContext(
-                    new UserContextSelectOptions(
-                        update.getMessage().getFrom().getId()
-                    )
-                );
-                if (userContextDTO != null && userContextDTO.getMultiStateCommandTypes() == CREATE) {
-                    isCreateDishContext = true; 
-                }
-            } catch (SQLException e) {
-                System.out.println(e);
-            }
-            return isCreateDishContext;
-        };
     }
 }

--- a/app/src/main/java/telegram/commands/DeleteDishCommand.java
+++ b/app/src/main/java/telegram/commands/DeleteDishCommand.java
@@ -92,29 +92,8 @@ public class DeleteDishCommand extends AbstractCommand {
                     }
                 },
                 Flag.TEXT,
-                isDeleteContext()
+                isSpecifiedContext(DELETE)
             )
             .build();
-    }
-    private Predicate<Update> isDeleteContext(){
-        return update -> {
-            boolean isDeleteContext = false;
-            if (update.getMessage().getText().equals("/end")){
-                return false;
-            }
-            try {
-                final UserContextDTO userContextDTO = dbDriver.selectUserContext(
-                    new UserContextSelectOptions(
-                        update.getMessage().getFrom().getId()
-                    )
-                );
-                if (userContextDTO != null && userContextDTO.getMultiStateCommandTypes() == DELETE) {
-                    isDeleteContext = true;
-                }
-            } catch(SQLException e) {
-                System.out.println(e);
-            }
-            return isDeleteContext;
-        };
     }
 }

--- a/app/src/main/java/telegram/commands/FeedbackCommand.java
+++ b/app/src/main/java/telegram/commands/FeedbackCommand.java
@@ -80,30 +80,8 @@ public class FeedbackCommand extends AbstractCommand {
                     }
                 },
                 Flag.TEXT,
-                isFeedbackContext()
+                isSpecifiedContext(FEEDBACK)
             )
             .build();
-    }
-
-    private Predicate<Update> isFeedbackContext(){
-        return update -> {
-            boolean isFeedbackContext = false;
-            if (update.getMessage().getText().equals("/end")){
-                return false;
-            }
-            try {
-                final UserContextDTO userContextDTO = dbDriver.selectUserContext(
-                    new UserContextSelectOptions(
-                        update.getMessage().getFrom().getId()
-                    )
-                );
-                if (userContextDTO != null && userContextDTO.getMultiStateCommandTypes() == FEEDBACK) {
-                    isFeedbackContext = true;
-                }
-            } catch(SQLException e) {
-                System.out.println(e);
-            }
-            return isFeedbackContext;
-        };
     }
 }

--- a/app/src/main/java/telegram/commands/GetDishCommand.java
+++ b/app/src/main/java/telegram/commands/GetDishCommand.java
@@ -90,7 +90,7 @@ public class GetDishCommand extends AbstractCommand {
                     }
                 },
                 Flag.TEXT,
-                isGetContext()
+                isSpecifiedContext(GET)
             )
             .build();
     }
@@ -125,27 +125,5 @@ public class GetDishCommand extends AbstractCommand {
         return recipe != null
             ? recipe
             : BotMessages.NO_INFO;
-    }
-
-    private Predicate<Update> isGetContext(){
-        return update -> {
-            boolean isGetContext = false;
-            if (update.getMessage().getText().equals("/end")){
-                return false;
-            }
-            try {
-                final UserContextDTO userContextDTO = dbDriver.selectUserContext(
-                    new UserContextSelectOptions(
-                        update.getMessage().getFrom().getId()
-                    )
-                );
-                if (userContextDTO != null && userContextDTO.getMultiStateCommandTypes() == GET) {
-                    isGetContext = true;
-                }
-            } catch(SQLException e) {
-                System.out.println(e);
-            }
-            return isGetContext;
-        };
     }
 }

--- a/app/src/main/java/telegram/commands/UpdateDishCommand.java
+++ b/app/src/main/java/telegram/commands/UpdateDishCommand.java
@@ -103,7 +103,7 @@ public class UpdateDishCommand extends AbstractCommand {
                     }
                 },
                 Flag.TEXT,
-                isUpdateContext()
+                isSpecifiedContext(UPDATE)
             )
             .build();
     }
@@ -324,27 +324,5 @@ public class UpdateDishCommand extends AbstractCommand {
             sendSilently(BotMessages.SOMETHING_WENT_WRONG, update);
             System.out.println(e);
         }
-    }
-
-    private Predicate<Update> isUpdateContext() {
-        return update -> {
-            boolean isUpdateContext = false;
-            if (update.getMessage().getText().equals("/end")){
-                return false;
-            }
-            try {
-                final UserContextDTO userContextDTO = dbDriver.selectUserContext(
-                    new UserContextSelectOptions(
-                        update.getMessage().getFrom().getId()
-                    )
-                );
-                if (userContextDTO != null && userContextDTO.getMultiStateCommandTypes() == UPDATE) {
-                    isUpdateContext = true;
-                }
-            } catch(SQLException e) {
-                System.out.println(e);
-            }
-            return isUpdateContext;
-        };
     }
 }


### PR DESCRIPTION
Т.к. все проверки на нужный контекст команды отличались только названием самой команды, то очевидно хорошим решением было вынести этот метод в абстрактный класс, где в роли параметра выступает само название команды
Собственно я это и сделал